### PR TITLE
feat: signed release pipeline + fix issue #3 web crash + green CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   OWNER: ${{ github.repository_owner }}
+  COSIGN_VERSION: v2.4.1
 
 jobs:
 
@@ -22,6 +23,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -42,6 +44,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           file: Dockerfile
@@ -52,12 +55,30 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=samba
           cache-to:   type=gha,scope=samba,mode=max
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+      - name: Sign image (keyless / GitHub OIDC)
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          echo "${TAGS}" | while IFS= read -r tag; do
+            [ -z "${tag}" ] && continue
+            echo "signing ${tag}@${DIGEST}"
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
 
   avahi:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -78,6 +99,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           file: Dockerfile
@@ -88,12 +110,29 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=avahi
           cache-to:   type=gha,scope=avahi,mode=max
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+      - name: Sign image (keyless / GitHub OIDC)
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          echo "${TAGS}" | while IFS= read -r tag; do
+            [ -z "${tag}" ] && continue
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
 
   web:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -114,6 +153,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
       - uses: docker/build-push-action@v6
+        id: build
         with:
           context: ./web
           platforms: linux/amd64,linux/arm64
@@ -122,3 +162,19 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=web
           cache-to:   type=gha,scope=web,mode=max
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+      - name: Sign image (keyless / GitHub OIDC)
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          echo "${TAGS}" | while IFS= read -r tag; do
+            [ -z "${tag}" ] && continue
+            cosign sign --yes "${tag}@${DIGEST}"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,232 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.2.0)"
+        required: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  TAG: ${{ github.event.inputs.tag || github.ref_name }}
+
+jobs:
+
+  # ---------------------------------------------------------------------------
+  # Build + codesign + notarize a macOS .pkg installer
+  # ---------------------------------------------------------------------------
+  macos-pkg:
+    runs-on: macos-14
+    outputs:
+      pkg_sha256: ${{ steps.hash.outputs.pkg_sha256 }}
+      pkg_name:   ${{ steps.hash.outputs.pkg_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+
+      - name: Resolve version
+        id: ver
+        run: |
+          v="${TAG#v}"
+          echo "version=${v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build unsigned .pkg
+        run: scripts/build-pkg.sh "${{ steps.ver.outputs.version }}"
+
+      - name: Import Developer ID Installer cert
+        env:
+          CERT_B64: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_CERT_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/build.keychain-db"
+          echo "${CERT_B64}" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/cert.p12" \
+              -k "$KEYCHAIN" \
+              -P "${CERT_PASSWORD}" \
+              -T /usr/bin/productsign \
+              -T /usr/bin/codesign
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          security default-keychain -s "$KEYCHAIN"
+          security set-key-partition-list -S apple-tool:,apple:,codesign:,productsign: \
+              -s -k "${KEYCHAIN_PASSWORD}" "$KEYCHAIN"
+
+      - name: Codesign .pkg
+        env:
+          SIGN_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_IDENTITY }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          UNSIGNED="dist/TimeNest-${VERSION}.pkg"
+          SIGNED="dist/TimeNest-${VERSION}-signed.pkg"
+          productsign --sign "${SIGN_IDENTITY}" "${UNSIGNED}" "${SIGNED}"
+          mv "${SIGNED}" "${UNSIGNED}"
+          pkgutil --check-signature "${UNSIGNED}"
+
+      - name: Notarize + staple
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_NOTARY_PASSWORD: ${{ secrets.APPLE_NOTARY_PASSWORD }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          PKG="dist/TimeNest-${VERSION}.pkg"
+          xcrun notarytool submit "${PKG}" \
+              --apple-id "${APPLE_ID}" \
+              --team-id "${APPLE_TEAM_ID}" \
+              --password "${APPLE_NOTARY_PASSWORD}" \
+              --wait
+          xcrun stapler staple "${PKG}"
+          xcrun stapler validate "${PKG}"
+
+      - name: SHA-256 the signed pkg
+        id: hash
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          PKG="dist/TimeNest-${VERSION}.pkg"
+          sha=$(shasum -a 256 "${PKG}" | awk '{print $1}')
+          echo "pkg_sha256=${sha}" >> "$GITHUB_OUTPUT"
+          echo "pkg_name=$(basename "${PKG}")" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: timenest-pkg
+          path: dist/*.pkg
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # Compute source tarball SHA for the Homebrew formula bump
+  # ---------------------------------------------------------------------------
+  tarball-hash:
+    runs-on: ubuntu-latest
+    outputs:
+      tar_sha256: ${{ steps.h.outputs.tar_sha256 }}
+      tar_url:    ${{ steps.h.outputs.tar_url }}
+      version:    ${{ steps.h.outputs.version }}
+    steps:
+      - id: h
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          v="${TAG#v}"
+          url="https://github.com/${REPO}/archive/refs/tags/${TAG}.tar.gz"
+          # GitHub may take ~30s after tag creation to materialize the tarball
+          for i in 1 2 3 4 5; do
+              if curl -fsSLI "${url}" >/dev/null; then break; fi
+              echo "tarball not ready yet (attempt ${i}); sleeping 20s"; sleep 20
+          done
+          sha=$(curl -fsSL "${url}" | sha256sum | awk '{print $1}')
+          echo "version=${v}"     >> "$GITHUB_OUTPUT"
+          echo "tar_sha256=${sha}" >> "$GITHUB_OUTPUT"
+          echo "tar_url=${url}"    >> "$GITHUB_OUTPUT"
+
+  # ---------------------------------------------------------------------------
+  # Publish GitHub release with notarized .pkg attached
+  # ---------------------------------------------------------------------------
+  publish-release:
+    needs: [macos-pkg, tarball-hash]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: timenest-pkg
+          path: dist
+      - name: Compose release body
+        env:
+          PKG_SHA: ${{ needs.macos-pkg.outputs.pkg_sha256 }}
+          TAR_SHA: ${{ needs.tarball-hash.outputs.tar_sha256 }}
+          VERSION: ${{ needs.tarball-hash.outputs.version }}
+        run: |
+          cat > NOTES.md <<EOF
+          ## TimeNest ${TAG}
+
+          ### macOS installer (signed + notarized)
+          \`dist/TimeNest-${VERSION}.pkg\`
+          SHA-256: \`${PKG_SHA}\`
+
+          ### Source tarball
+          SHA-256: \`${TAR_SHA}\`
+
+          ### Docker images
+          All images are signed via cosign (keyless / GitHub OIDC). Verify:
+          \`\`\`
+          cosign verify ghcr.io/momenbasel/timenest-samba:${VERSION} \\
+              --certificate-identity-regexp 'https://github.com/momenbasel/timenest/' \\
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com
+          \`\`\`
+          EOF
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          name: TimeNest ${{ env.TAG }}
+          body_path: NOTES.md
+          files: dist/*.pkg
+
+  # ---------------------------------------------------------------------------
+  # Bump the Homebrew tap formula
+  # ---------------------------------------------------------------------------
+  bump-tap:
+    needs: [macos-pkg, tarball-hash, publish-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: momenbasel/homebrew-timenest
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - uses: actions/checkout@v4
+        with:
+          path: src
+          ref: ${{ env.TAG }}
+
+      - name: Rewrite Formula/timenest.rb
+        env:
+          VERSION: ${{ needs.tarball-hash.outputs.version }}
+          TAR_URL: ${{ needs.tarball-hash.outputs.tar_url }}
+          TAR_SHA: ${{ needs.tarball-hash.outputs.tar_sha256 }}
+        run: |
+          set -euo pipefail
+          mkdir -p tap/Formula
+          cp src/homebrew/timenest.rb tap/Formula/timenest.rb
+          sed -i \
+              -e "s|^  url \".*\"|  url \"${TAR_URL}\"|" \
+              -e "s|^  sha256 \".*\"|  sha256 \"${TAR_SHA}\"|" \
+              -e "s|^  version \".*\"|  version \"${VERSION}\"|" \
+              tap/Formula/timenest.rb
+          grep -E '^  (url|sha256|version) ' tap/Formula/timenest.rb
+
+      - name: Commit + push tap update
+        working-directory: tap
+        env:
+          VERSION: ${{ needs.tarball-hash.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name  "timenest-release-bot"
+          git config user.email "release-bot@users.noreply.github.com"
+          git add Formula/timenest.rb
+          if git diff --cached --quiet; then
+              echo "no changes; nothing to commit"; exit 0
+          fi
+          git commit -m "timenest ${VERSION}"
+          git push origin HEAD

--- a/bin/timenest
+++ b/bin/timenest
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# TimeNest CLI wrapper.
+#
+# Installed by Homebrew and the macOS .pkg into PATH. Thin shim over
+# `docker compose` so users don't have to remember the compose file path.
+#
+# Usage:
+#   timenest up            # start the stack (detached)
+#   timenest down          # stop the stack
+#   timenest logs [svc]    # tail logs for one or all services
+#   timenest status        # show container status
+#   timenest update        # pull latest images and recreate
+#   timenest path          # print the install dir
+#   timenest version       # print the installed version
+
+set -euo pipefail
+
+# TIMENEST_HOME is set by the Homebrew formula / .pkg postinstall script.
+# Fall back to ~/timenest for source installs.
+TIMENEST_HOME="${TIMENEST_HOME:-$HOME/timenest}"
+COMPOSE_FILE="${TIMENEST_HOME}/docker-compose.yml"
+VERSION_FILE="${TIMENEST_HOME}/.version"
+
+die() { printf 'timenest: %s\n' "$*" >&2; exit 1; }
+
+[ -f "$COMPOSE_FILE" ] || die "compose file not found at $COMPOSE_FILE; reinstall TimeNest"
+command -v docker >/dev/null 2>&1 || die "docker is required; install Docker Desktop from https://www.docker.com/"
+
+cmd="${1:-status}"
+shift || true
+
+case "$cmd" in
+    up)      exec docker compose -f "$COMPOSE_FILE" --project-directory "$TIMENEST_HOME" up -d "$@" ;;
+    down)    exec docker compose -f "$COMPOSE_FILE" --project-directory "$TIMENEST_HOME" down "$@" ;;
+    logs)    exec docker compose -f "$COMPOSE_FILE" --project-directory "$TIMENEST_HOME" logs -f "$@" ;;
+    status|ps)
+             exec docker compose -f "$COMPOSE_FILE" --project-directory "$TIMENEST_HOME" ps "$@" ;;
+    update)
+             docker compose -f "$COMPOSE_FILE" --project-directory "$TIMENEST_HOME" pull
+             exec docker compose -f "$COMPOSE_FILE" --project-directory "$TIMENEST_HOME" up -d "$@"
+             ;;
+    path)    printf '%s\n' "$TIMENEST_HOME" ;;
+    version) [ -f "$VERSION_FILE" ] && cat "$VERSION_FILE" || echo "unknown" ;;
+    -h|--help|help)
+        cat <<'USAGE'
+timenest - manage your TimeNest Time Machine server
+
+  up         Start the stack (docker compose up -d)
+  down       Stop the stack
+  logs [svc] Tail logs for all services or one service
+  status     Show container status (alias: ps)
+  update     Pull latest images and recreate
+  path       Print TIMENEST_HOME
+  version    Print installed version
+USAGE
+        ;;
+    *) die "unknown command '$cmd' (run 'timenest help')" ;;
+esac

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -1,0 +1,75 @@
+# TimeNest release pipeline
+
+Triggered by pushing a `v*` tag (or via `workflow_dispatch`). One tag push
+produces:
+
+| Artifact                                      | Workflow              | Signing |
+|-----------------------------------------------|-----------------------|---------|
+| `ghcr.io/momenbasel/timenest-{samba,avahi,web}` multi-arch images | `docker.yml`     | cosign keyless (GitHub OIDC) |
+| `dist/TimeNest-<version>.pkg` (macOS installer)                   | `release.yml`    | Developer ID Installer + notarytool staple |
+| GitHub release with `.pkg` attached                               | `release.yml`    | - |
+| `momenbasel/homebrew-timenest` formula bump commit                | `release.yml`    | - |
+
+## Required repository secrets
+
+| Secret                                       | Purpose |
+|----------------------------------------------|---------|
+| `APPLE_DEVELOPER_ID_INSTALLER_CERT_BASE64`   | `base64 < DeveloperIDInstaller.p12` of the exported "Developer ID Installer" certificate. |
+| `APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD` | Password used when exporting the .p12 above. |
+| `APPLE_DEVELOPER_ID_INSTALLER_IDENTITY`      | Exact identity string, e.g. `Developer ID Installer: Greycore Labs (TEAMID12)`. |
+| `APPLE_KEYCHAIN_PASSWORD`                    | Throwaway password the runner uses to create + unlock the build keychain. |
+| `APPLE_ID`                                   | Apple Developer account email. |
+| `APPLE_TEAM_ID`                              | 10-character Team ID from the Developer portal. |
+| `APPLE_NOTARY_PASSWORD`                      | App-specific password generated at appleid.apple.com (NOT your Apple ID password). |
+| `HOMEBREW_TAP_TOKEN`                         | Fine-grained PAT with `Contents: read/write` on `momenbasel/homebrew-timenest`. |
+
+`cosign` itself needs no secrets - the docker workflow already requests
+`id-token: write` and signs against the public Sigstore Fulcio root
+using GitHub's OIDC token.
+
+## One-time bootstrap
+
+1. **Create the tap repo.** `gh repo create momenbasel/homebrew-timenest --public --description "Homebrew tap for TimeNest"` then push an initial commit containing only `README.md`. The release workflow writes `Formula/timenest.rb` on first run.
+2. **Generate the Apple cert.** In Xcode > Settings > Accounts, request a "Developer ID Installer" certificate. Export it to `.p12` with a password. `base64 < cert.p12 | pbcopy` and paste into `APPLE_DEVELOPER_ID_INSTALLER_CERT_BASE64`.
+3. **App-specific password.** Sign in at appleid.apple.com > Sign-In and Security > App-Specific Passwords > Generate. Label it `timenest-notary`. This is `APPLE_NOTARY_PASSWORD`.
+4. **PAT for the tap.** github.com > Settings > Developer settings > Fine-grained tokens > Generate. Scope it to the `homebrew-timenest` repo with `Contents: read and write`. Paste into `HOMEBREW_TAP_TOKEN`.
+
+## Cutting a release
+
+```
+git tag -a v0.2.0 -m "v0.2.0"
+git push origin v0.2.0
+```
+
+That fires:
+
+1. `docker.yml` - builds + signs all three images for the new tag.
+2. `release.yml` - builds, signs, and notarizes the `.pkg`; computes the tarball SHA; publishes the GitHub release with the `.pkg` attached; pushes a formula-bump commit to the tap.
+
+## Verifying the artifacts
+
+```bash
+# Verify a Docker image's cosign signature
+cosign verify ghcr.io/momenbasel/timenest-web:v0.2.0 \
+    --certificate-identity-regexp 'https://github.com/momenbasel/timenest/' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+# Verify the macOS installer's signature + notarization
+pkgutil --check-signature dist/TimeNest-0.2.0.pkg
+spctl --assess --type install --verbose dist/TimeNest-0.2.0.pkg
+
+# Verify the Homebrew install path
+brew tap momenbasel/timenest
+brew install --formula timenest
+timenest version
+```
+
+## Local repro of the .pkg build
+
+```bash
+scripts/build-pkg.sh 0.2.0
+# Output: dist/TimeNest-0.2.0.pkg  (unsigned)
+```
+
+The codesign + notarize steps live in `release.yml` only; running them
+locally requires the same secrets installed in your keychain.

--- a/homebrew/timenest.rb
+++ b/homebrew/timenest.rb
@@ -1,0 +1,66 @@
+# Homebrew formula for TimeNest.
+#
+# Canonical source lives in the main repo at homebrew/timenest.rb. The
+# tap (momenbasel/homebrew-timenest) hosts an identical copy. The
+# release workflow rewrites url + sha256 + version on every tagged
+# release and opens a PR against the tap.
+#
+# Install:
+#   brew tap momenbasel/timenest
+#   brew install timenest
+class Timenest < Formula
+  desc "Network Time Machine server (Samba + Avahi + admin UI) for Mac, RPi, and Linux"
+  homepage "https://github.com/momenbasel/timenest"
+  url "https://github.com/momenbasel/timenest/archive/refs/tags/v0.0.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "MIT"
+  version "0.0.0"
+
+  depends_on "bash"
+
+  def install
+    # Stage the compose stack, scripts, and config templates under libexec.
+    libexec.install "docker-compose.yml"
+    libexec.install ".env.example"
+    libexec.install "install.sh"
+    libexec.install "samba"
+    libexec.install "avahi"
+    libexec.install "scripts"
+    libexec.install "web"
+    (libexec/".version").write version.to_s
+
+    # CLI wrapper goes on PATH; default TIMENEST_HOME points at libexec
+    # so users don't have to clone the repo.
+    bin.install "bin/timenest"
+    inreplace bin/"timenest", 'TIMENEST_HOME="${TIMENEST_HOME:-$HOME/timenest}"',
+              "TIMENEST_HOME=\"${TIMENEST_HOME:-#{libexec}}\""
+  end
+
+  def caveats
+    <<~EOS
+      TimeNest requires Docker. Install Docker Desktop or OrbStack first:
+        brew install --cask docker     # or: brew install --cask orbstack
+
+      First-run setup (creates ~/.timenest with .env + backup dir):
+        timenest up
+
+      Manage the stack:
+        timenest status    # show container status
+        timenest logs      # tail logs
+        timenest update    # pull latest images
+        timenest down      # stop everything
+    EOS
+  end
+
+  service do
+    run [opt_bin/"timenest", "up"]
+    keep_alive false
+    log_path var/"log/timenest.log"
+    error_log_path var/"log/timenest.log"
+  end
+
+  test do
+    assert_match "timenest", shell_output("#{bin}/timenest --help")
+    assert_predicate libexec/"docker-compose.yml", :exist?
+  end
+end

--- a/scripts/build-pkg.sh
+++ b/scripts/build-pkg.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Build a macOS .pkg installer that places the TimeNest CLI + compose
+# stack under /usr/local/timenest and symlinks /usr/local/bin/timenest.
+#
+# Reproducible locally and from CI. Codesigning + notarization happen
+# in the release workflow; this script just produces the unsigned .pkg.
+#
+# Usage:
+#   scripts/build-pkg.sh <version>
+#
+# Output:
+#   dist/TimeNest-<version>.pkg
+
+set -euo pipefail
+
+VERSION="${1:?usage: build-pkg.sh <version>}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD="${REPO_ROOT}/build/pkg"
+DIST="${REPO_ROOT}/dist"
+ROOT="${BUILD}/root"
+SCRIPTS="${BUILD}/scripts"
+PREFIX="/usr/local/timenest"
+
+PKG_ID="${PKG_ID:-com.greycorelabs.timenest}"
+
+rm -rf "$BUILD" "$DIST/TimeNest-${VERSION}.pkg"
+mkdir -p "${ROOT}${PREFIX}" "${ROOT}/usr/local/bin" "${SCRIPTS}" "${DIST}"
+
+# ---------------------------------------------------------------------------
+# Stage payload
+# ---------------------------------------------------------------------------
+cp "${REPO_ROOT}/docker-compose.yml" "${ROOT}${PREFIX}/docker-compose.yml"
+cp "${REPO_ROOT}/.env.example"       "${ROOT}${PREFIX}/.env.example"
+cp "${REPO_ROOT}/install.sh"         "${ROOT}${PREFIX}/install.sh"
+cp -R "${REPO_ROOT}/samba"           "${ROOT}${PREFIX}/samba"
+cp -R "${REPO_ROOT}/avahi"           "${ROOT}${PREFIX}/avahi"
+cp -R "${REPO_ROOT}/scripts"         "${ROOT}${PREFIX}/scripts"
+cp -R "${REPO_ROOT}/web"             "${ROOT}${PREFIX}/web"
+printf '%s\n' "$VERSION" > "${ROOT}${PREFIX}/.version"
+
+# CLI wrapper, rewritten so TIMENEST_HOME points at the pkg install dir.
+# shellcheck disable=SC2016  # single-quoted pattern intentional; we want literal $ in sed match
+sed 's|TIMENEST_HOME="\${TIMENEST_HOME:-\$HOME/timenest}"|TIMENEST_HOME="${TIMENEST_HOME:-'"${PREFIX}"'}"|' \
+    "${REPO_ROOT}/bin/timenest" > "${ROOT}/usr/local/bin/timenest"
+chmod 0755 "${ROOT}/usr/local/bin/timenest"
+
+# ---------------------------------------------------------------------------
+# postinstall: chmod helpers, create launchd plist optionally
+# ---------------------------------------------------------------------------
+cat > "${SCRIPTS}/postinstall" <<'POST'
+#!/bin/bash
+set -e
+chmod 0755 /usr/local/timenest/install.sh
+chmod 0755 /usr/local/timenest/scripts/*.sh
+exit 0
+POST
+chmod 0755 "${SCRIPTS}/postinstall"
+
+# ---------------------------------------------------------------------------
+# Component + product pkg
+# ---------------------------------------------------------------------------
+COMPONENT="${BUILD}/TimeNest-component.pkg"
+pkgbuild \
+    --root "${ROOT}" \
+    --identifier "${PKG_ID}" \
+    --version "${VERSION}" \
+    --scripts "${SCRIPTS}" \
+    --install-location "/" \
+    "${COMPONENT}"
+
+cat > "${BUILD}/distribution.xml" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="2">
+    <title>TimeNest</title>
+    <organization>com.greycorelabs</organization>
+    <domains enable_localSystem="true"/>
+    <options customize="never" require-scripts="false" rootVolumeOnly="true" hostArchitectures="x86_64,arm64"/>
+    <pkg-ref id="${PKG_ID}"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="${PKG_ID}"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="${PKG_ID}" visible="false">
+        <pkg-ref id="${PKG_ID}"/>
+    </choice>
+    <pkg-ref id="${PKG_ID}" version="${VERSION}" onConclusion="none">TimeNest-component.pkg</pkg-ref>
+</installer-gui-script>
+XML
+
+productbuild \
+    --distribution "${BUILD}/distribution.xml" \
+    --package-path "${BUILD}" \
+    --version "${VERSION}" \
+    "${DIST}/TimeNest-${VERSION}.pkg"
+
+echo "built ${DIST}/TimeNest-${VERSION}.pkg"

--- a/scripts/entrypoint-avahi.sh
+++ b/scripts/entrypoint-avahi.sh
@@ -17,6 +17,7 @@ export SERVER_NAME DEVICE_MODEL
 
 mkdir -p /etc/avahi/services
 
+# shellcheck disable=SC2016  # single quotes intentional; envsubst reads literal ${VAR} list
 envsubst '${SERVER_NAME} ${DEVICE_MODEL}' \
     < /etc/timenest/timenest.service.template \
     > /etc/avahi/services/timenest.service

--- a/scripts/entrypoint-samba.sh
+++ b/scripts/entrypoint-samba.sh
@@ -46,6 +46,7 @@ mkdir -p /etc/samba /etc/timenest/shares.d /var/lib/samba/private /var/log/samba
 
 # The template uses ${VAR} syntax - envsubst only replaces explicitly
 # listed vars to avoid accidentally eating literal `$` in comments.
+# shellcheck disable=SC2016  # single quotes intentional; envsubst reads literal ${VAR} list
 envsubst '${SERVER_NAME} ${DEVICE_MODEL} ${SMB_INTERFACES} ${BIND_INTERFACES_ONLY} ${SAMBA_LOG_LEVEL}' \
     < /etc/timenest/smb.conf.template \
     > /etc/samba/smb.conf

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,14 +5,31 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-        curl \
-        smartmontools \
-        docker.io \
-        ca-certificates \
-        tini \
- && rm -rf /var/lib/apt/lists/*
+ARG TARGETARCH
+ARG DOCKER_CLI_VERSION=27.3.1
+
+# We need the docker CLI (only, not the daemon) so the web container can run
+# `docker exec timenest-samba ...` against the host docker.sock. The Debian
+# `docker.io` package pulls in the full daemon (~200 MB) and was unreliable on
+# slim arm64 (issue #3: FileNotFoundError on the `docker` binary). Pulling the
+# static CLI build from download.docker.com gives us a single 30 MB binary
+# that works identically on amd64 and arm64.
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        curl smartmontools ca-certificates tini; \
+    case "${TARGETARCH:-amd64}" in \
+        amd64) dockerArch=x86_64 ;; \
+        arm64) dockerArch=aarch64 ;; \
+        *) echo "unsupported TARGETARCH ${TARGETARCH}"; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://download.docker.com/linux/static/stable/${dockerArch}/docker-${DOCKER_CLI_VERSION}.tgz" \
+        -o /tmp/docker.tgz; \
+    tar -xzf /tmp/docker.tgz -C /tmp; \
+    install -m 0755 /tmp/docker/docker /usr/local/bin/docker; \
+    rm -rf /tmp/docker /tmp/docker.tgz; \
+    docker --version; \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/web/app/auth.py
+++ b/web/app/auth.py
@@ -8,7 +8,7 @@ attack surface.
 from __future__ import annotations
 
 import secrets
-from typing import Callable
+from typing import cast
 
 from fastapi import Depends, HTTPException, Request, status
 from passlib.hash import bcrypt
@@ -47,4 +47,7 @@ def require_login(request: Request) -> str:
     return user
 
 
-LoginDep: Callable[..., str] = Depends(require_login)
+# Runtime value is `fastapi.params.Depends`, but FastAPI substitutes the
+# resolved string at call time. Cast so endpoints can declare `user: str = LoginDep`
+# without mypy complaining about a Callable default for a str argument.
+LoginDep: str = cast(str, Depends(require_login))

--- a/web/app/auth.py
+++ b/web/app/auth.py
@@ -13,7 +13,7 @@ from typing import Callable
 from fastapi import Depends, HTTPException, Request, status
 from passlib.hash import bcrypt
 
-from .config import Settings, get_settings
+from .config import Settings
 
 
 def verify_login(username: str, password: str, settings: Settings) -> bool:

--- a/web/app/samba_mgr.py
+++ b/web/app/samba_mgr.py
@@ -152,11 +152,20 @@ class SambaManager:
             self.settings.samba_container,
             *args,
         ]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            # Translate "docker CLI missing" into RuntimeError so callers
+            # that already catch RuntimeError (list_sessions) degrade
+            # gracefully instead of returning a 500 to the browser.
+            raise RuntimeError(
+                f"{cmd[0]} not found in PATH; install docker CLI or mount "
+                f"the host binary into the web container"
+            ) from exc
         stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
             raise RuntimeError(


### PR DESCRIPTION
## Summary

- **Fix issue #3** (`FileNotFoundError` 500 on dashboard): harden `samba_mgr._exec` so the dashboard degrades to an empty session list, and replace the unreliable `docker.io` apt package in `web/Dockerfile` with the pinned static docker CLI binary from download.docker.com.
- **Unbreak CI**: drop an unused `get_settings` import (ruff F401) and add targeted `# shellcheck disable=SC2016` directives next to the intentional single-quoted `envsubst` calls. Unblocks dependabot PR #4.
- **Release pipeline**:
  - `docker.yml` now installs `sigstore/cosign-installer` and signs every pushed image keylessly via GitHub OIDC.
  - New `release.yml` (tag-triggered) builds a macOS `.pkg`, codesigns with Developer ID Installer, notarizes + staples via `notarytool`, attaches it to the GitHub release, then pushes a `Formula/timenest.rb` bump to `momenbasel/homebrew-timenest`.
  - `scripts/build-pkg.sh` is a reproducible local + CI builder (productbuild).
  - `bin/timenest` is the CLI shim used by both Homebrew and the `.pkg`.
  - `homebrew/timenest.rb` is the canonical formula; the workflow rewrites `url`/`sha256`/`version` on each tag.
  - `docs/release-pipeline.md` documents the required secrets, the one-time bootstrap (tap repo, Apple cert, notary password, PAT), and verify commands.

Closes #3.

## Required secrets before cutting the first release
See `docs/release-pipeline.md` for full details. TL;DR:
- `APPLE_DEVELOPER_ID_INSTALLER_CERT_BASE64`
- `APPLE_DEVELOPER_ID_INSTALLER_CERT_PASSWORD`
- `APPLE_DEVELOPER_ID_INSTALLER_IDENTITY`
- `APPLE_KEYCHAIN_PASSWORD`
- `APPLE_ID`
- `APPLE_TEAM_ID`
- `APPLE_NOTARY_PASSWORD` (app-specific password)
- `HOMEBREW_TAP_TOKEN` (fine-grained PAT scoped to the tap repo)

Cosign needs no secrets; it uses the workflow's OIDC token + Sigstore Fulcio.

## Test plan
- [x] `ruff check web/` passes locally
- [x] `shellcheck` (with CI opts) passes on all scripts incl. new `bin/timenest` and `scripts/build-pkg.sh`
- [ ] CI green on this PR
- [ ] After merge: comment `@dependabot rebase` on #4, confirm green, merge
- [ ] Tag a `v*` after secrets are added; verify cosign signature on a pushed image and `pkgutil --check-signature` on the produced `.pkg`
- [ ] `brew tap momenbasel/timenest && brew install timenest && timenest --help`